### PR TITLE
style(purchase portal): Fix button and text area

### DIFF
--- a/public/stylesheets/purchase-portal/purchase-portal.css
+++ b/public/stylesheets/purchase-portal/purchase-portal.css
@@ -136,7 +136,8 @@
   justify-content: space-between;
 }
 
-.purchase-request-form__floating-input-container {
+.purchase-request-form__floating-input-container,
+.purchase-request-edit-form__floating-input-container {
   width: 100%;
 }
 
@@ -162,6 +163,7 @@
 .purchase-request-form__btns {
   display: flex;
   justify-content: space-between;
+  width: 100%;
 }
 
 .purchase-request-form__edit-btn {

--- a/views/purchase-portal/purchase-portal.hbs
+++ b/views/purchase-portal/purchase-portal.hbs
@@ -102,7 +102,7 @@
       <output><strong>Reviewed by:</strong> {{reviewedBy.firstName}} {{reviewedBy.lastName}}</output>
       {{/if}}
       {{#if (isPendingAndIsUserManager this ../currentUser)}}
-      <div class="form-floating mb-3 purchase-request-edit-form__floating-input-container">
+      <div class="form-floating mb-3 mt-1 purchase-request-edit-form__floating-input-container">
       <textarea class="form-control" placeholder="Manager's comment" id="floatingTextarea" name="comment" id="comment" style="height: 75px;"></textarea>
       <label for="comment">Manager's comment</label>
       </div>


### PR DESCRIPTION
- Make the buttons in the purchase request item card be spaced apart.

- Make the manager's comment field on the purchase requests fill the whole card. Set the width to 100%;